### PR TITLE
Update for py37

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,4 @@ vars/
 __generated__/
 
 .mypy_cache
+\.idea/

--- a/kforce/aws_facts.py
+++ b/kforce/aws_facts.py
@@ -31,8 +31,8 @@ def check_rt_internet_facing(facing, route_table):  # pragma: no cover
         return len(routes_facing_igw) == 0 and len(routes_facing_nat) > 0, nat_id  # yapf: disable
 
 
-def get_vpc_facts(vpc_id):  # pragma: no cover
-    ec2_c = boto3.resource('ec2')
+def get_vpc_facts(vpc_id, region_name='ap-southeast-2'):  # pragma: no cover
+    ec2_c = boto3.resource('ec2', region_name=region_name)
     vpc_c = ec2_c.Vpc(id=vpc_id)
 
     vpc = dict(id=vpc_id, cidr=vpc_c.cidr_block)

--- a/kforce/pre_steps.py
+++ b/kforce/pre_steps.py
@@ -15,7 +15,7 @@ logger = logging.getLogger(__name__)
 
 
 def ensure_aws_facts(self):
-    self.vpc_facts = get_vpc_facts(vpc_id=self.vpc_id)
+    self.vpc_facts = get_vpc_facts(vpc_id=self.vpc_id, region_name=self.region)
     logger.debug('vpc_facts -> \n%s', pformat(self.vpc_facts, indent=4, width=120))
 
 

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,5 +1,5 @@
-boto3==1.5.25
+boto3>=1.5.25
 fire==0.1.2
-awscli==1.14.35
+awscli>=1.14.35
 Jinja2==2.10
-PyYAML==3.12
+PyYAML==3.13

--- a/setup.py
+++ b/setup.py
@@ -1,8 +1,12 @@
 import os
 import sys
 from setuptools import setup
-from pip.req import parse_requirements
-from pip.download import PipSession
+try: # for pip >= 10
+    from pip._internal.req import parse_requirements
+    from pip._internal.download import PipSession
+except ImportError: # for pip <= 9.0.3
+    from pip.req import parse_requirements
+    from pip.download import PipSession
 
 VERSION = "0.1.26"
 


### PR DESCRIPTION
Small changes to dependencies to update for Python 3.7. PyYAML specifically doesn't compile under 3.7, although it does in 3.6. I think ultimately we should add e.g. tox.ini and do multi-version testing, but for now this unblocks me. :-)